### PR TITLE
chore: tighten MCP server typings and add Spanish guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,59 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing pages by modifying `.tsx` files. The page auto-updates as you edit the file.
 
+## Model Context Protocol connector
+
+This repository ships with an MCP (Model Context Protocol) server that exposes Helldivers 2 data to ChatGPT via stdio. The server
+resides in `connectors/helldivers-mcp/` and reuses the shared `lib/get.ts` helpers to communicate with `https://api.helldivers2.dev`.
+
+### Run locally
+
+```bash
+pnpm install
+pnpm run connectors:dev
+```
+
+The development command runs the server with hot reloading through `tsx`. It logs a confirmation message once a client connects.
+
+To type-check the connector and run the server:
+
+```bash
+pnpm run connectors:start
+```
+
+This script type-checks the MCP connector before launching the stdio server.
+
+### Configure ChatGPT
+
+In the ChatGPT “Connectors” form choose **Custom**, then provide the following command configuration:
+
+- **Command:** `pnpm`
+- **Arguments:** `run`, `connectors:start`
+- **Working directory:** Root of this repository
+
+Because the connector uses stdio transport no additional network port configuration is required. The exposed tools include
+`getWarStatus`, `getDispatches`, `getMajorOrders`, and `getActiveCampaigns`, each returning structured JSON payloads with built-in
+timeouts and rate limiting suitable for conversational use.
+
+### Guía rápida en español
+
+1. **Instala las dependencias**
+   - Asegúrate de tener [pnpm](https://pnpm.io/installation) instalado.
+   - Ejecuta `pnpm install` en la raíz del repositorio para preparar todas las dependencias del monorrepo y del conector MCP.
+2. **Prueba el servidor MCP en local**
+   - Lanza `pnpm run connectors:dev` para iniciar el servidor con recarga en caliente.
+   - En la terminal deberías ver el mensaje `[helldivers-mcp] Server ready and listening on stdio.` indicando que todo está listo.
+3. **Configura el conector en ChatGPT**
+   - En ChatGPT abre la sección **Connectors** y elige la opción **Custom**.
+   - Introduce lo siguiente en el formulario:
+     - **Command:** `pnpm`
+     - **Arguments:** `run`, `connectors:start`
+     - **Working directory:** la ruta del repositorio que contiene este proyecto.
+   - Guarda la configuración. ChatGPT ejecutará el comando anterior y conectará vía stdio con el servidor MCP.
+4. **Usa las herramientas disponibles**
+   - Desde ChatGPT podrás invocar herramientas como `getWarStatus`, `getDispatches`, `getMajorOrders` o `getActiveCampaigns`.
+   - Cada herramienta valida los parámetros de entrada, impone un límite de peticiones para evitar abusos y responde con JSON fácil de consumir en la conversación.
+
 ## Contributing
 
 Contributions are welcome! Fork the repo, make your changes, and submit a pull request.

--- a/connectors/helldivers-mcp/package.json
+++ b/connectors/helldivers-mcp/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "helldivers-mcp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/server.ts",
+  "types": "src/server.ts",
+  "scripts": {
+    "dev": "tsx watch --clear-screen=false src/server.ts",
+    "build": "tsc --noEmit --project tsconfig.json",
+    "start": "tsx src/server.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^0.6.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.2"
+  }
+}

--- a/connectors/helldivers-mcp/src/server.ts
+++ b/connectors/helldivers-mcp/src/server.ts
@@ -1,0 +1,452 @@
+import { Server } from "@modelcontextprotocol/sdk/server";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio";
+import {
+  CallToolRequestSchema,
+  type CallToolRequest,
+  type CallToolResult,
+  ListToolsRequestSchema,
+  type Tool,
+} from "@modelcontextprotocol/sdk/types";
+import { z } from "zod";
+
+const JSON_MIME_TYPE = "application/json";
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_RATE_LIMIT_MS = 2_000;
+
+type GetAPIModule = typeof import("../../../lib/get");
+type GetAPIParams = Parameters<GetAPIModule["getAPI"]>[0];
+
+async function callGetAPI<TResponse>(params: GetAPIParams) {
+  const module = (await import(
+    new URL("../../../lib/get.ts", import.meta.url).href
+  )) as GetAPIModule;
+
+  return module.getAPI(params) as Promise<TResponse>;
+}
+
+const rateLimiter = new Map<string, number>();
+
+function assertRateLimit(toolName: string, minIntervalMs: number) {
+  const now = Date.now();
+  const lastCall = rateLimiter.get(toolName) ?? 0;
+
+  if (now - lastCall < minIntervalMs) {
+    const waitTimeMs = minIntervalMs - (now - lastCall);
+    throw new Error(
+      `Rate limit exceeded for ${toolName}. Try again in ${Math.ceil(waitTimeMs / 1000)}s.`
+    );
+  }
+}
+
+function createJsonContent(uri: string, data: unknown) {
+  return {
+    type: "resource" as const,
+    resource: {
+      uri,
+      mimeType: JSON_MIME_TYPE,
+      text: JSON.stringify(data, null, 2),
+    },
+  };
+}
+
+function createSuccessResult(uri: string, data: unknown): CallToolResult {
+  return {
+    content: [createJsonContent(uri, data)],
+    isError: false,
+  };
+}
+
+function createErrorResult(message: string, details?: unknown): CallToolResult {
+  return {
+    content: [
+      createJsonContent("urn:helldivers:mcp:error", {
+        error: message,
+        details,
+      }),
+    ],
+    isError: true,
+  };
+}
+
+function sanitizeDispatchMessage(message: string) {
+  return message
+    .replace(/<i=\d+>(.*?)<\/i>/g, "")
+    .replace(/<span(.*?)>/g, "")
+    .replace(/<\/span>/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+type JsonSchema = {
+  type: "object";
+  properties?: Record<string, unknown>;
+  required?: string[];
+  additionalProperties?: boolean;
+};
+
+type ToolDefinition<TSchema extends z.ZodTypeAny> = {
+  description: string;
+  inputSchema: JsonSchema;
+  schema: TSchema;
+  minIntervalMs?: number;
+  execute: (input: z.infer<TSchema>) => Promise<CallToolResult>;
+};
+
+type WarStatusResponse = {
+  started: string;
+  ended: string | null;
+  now: string;
+  clientVersion?: string;
+  impactMultiplier?: number;
+  factions?: unknown;
+  statistics?: Record<string, unknown>;
+};
+
+type Dispatch = {
+  id: number;
+  published: string;
+  type: number;
+  message: string;
+};
+
+type Assignment = {
+  id: number;
+  progress: number[];
+  title: string;
+  briefing: string;
+  description?: string | null;
+  tasks: Array<Record<string, unknown>>;
+  reward: Record<string, unknown> | null;
+  rewards?: Array<Record<string, unknown>>;
+  expiration: string;
+};
+
+type Campaign = {
+  id: number;
+  planet: {
+    name: string;
+    sector: string;
+    biome?: { name: string; description?: string } | null;
+    hazards?: Array<{ name: string; description?: string }>;
+    currentOwner?: string;
+    initialOwner?: string;
+    maxHealth?: number;
+    health?: number;
+    regenPerSecond?: number;
+    statistics?: Record<string, unknown>;
+  };
+};
+
+const toolDefinitions = {
+  getWarStatus: {
+    description: "Fetches the latest status of the Galactic War, including optional aggregate statistics.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        includeStatistics: {
+          type: "boolean",
+          description: "Whether to include global war statistics (defaults to true).",
+        },
+      },
+      additionalProperties: false,
+    },
+    schema: z
+      .object({
+        includeStatistics: z.boolean().optional(),
+      })
+      .strict(),
+    minIntervalMs: DEFAULT_RATE_LIMIT_MS,
+    async execute(input) {
+      const { includeStatistics = true } = input;
+
+      const data = await callGetAPI<WarStatusResponse>({
+        url: "/v1/war",
+        revalidate: false,
+        timeout: DEFAULT_TIMEOUT_MS,
+      });
+
+      const result: Record<string, unknown> = {
+        started: data.started,
+        ended: data.ended,
+        now: data.now,
+        clientVersion: data.clientVersion,
+        impactMultiplier: data.impactMultiplier,
+        factions: data.factions,
+      };
+
+      if (includeStatistics && data.statistics) {
+        result.statistics = data.statistics;
+      }
+
+      return createSuccessResult("urn:helldivers:mcp:getWarStatus", result);
+    },
+  },
+  getDispatches: {
+    description: "Returns the latest dispatches from Super Earth High Command with optional HTML sanitization.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        limit: {
+          type: "integer",
+          minimum: 1,
+          maximum: 50,
+          description: "Maximum number of dispatches to return (defaults to 5).",
+        },
+        sanitize: {
+          type: "boolean",
+          description: "Remove markup tags from messages (defaults to true).",
+        },
+      },
+      additionalProperties: false,
+    },
+    schema: z
+      .object({
+        limit: z.number().int().min(1).max(50).optional(),
+        sanitize: z.boolean().optional(),
+      })
+      .strict(),
+    minIntervalMs: 3_000,
+    async execute(input) {
+      const { limit = 5, sanitize = true } = input;
+
+      const dispatches = await callGetAPI<Dispatch[]>({
+        url: "/v2/dispatches",
+        revalidate: false,
+        timeout: DEFAULT_TIMEOUT_MS,
+      });
+
+      const slice = dispatches.slice(0, limit).map((dispatch) => ({
+        id: dispatch.id,
+        published: dispatch.published,
+        type: dispatch.type,
+        message: dispatch.message,
+        plainText: sanitize ? sanitizeDispatchMessage(dispatch.message) : undefined,
+      }));
+
+      return createSuccessResult("urn:helldivers:mcp:getDispatches", {
+        total: dispatches.length,
+        results: slice,
+      });
+    },
+  },
+  getMajorOrders: {
+    description: "Lists currently active Major Orders, including objectives, rewards, and expiry information.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        limit: {
+          type: "integer",
+          minimum: 1,
+          maximum: 10,
+          description: "Maximum number of Major Orders to include (defaults to 3).",
+        },
+        includeTasks: {
+          type: "boolean",
+          description: "Include raw task data for each assignment (defaults to false).",
+        },
+      },
+      additionalProperties: false,
+    },
+    schema: z
+      .object({
+        limit: z.number().int().min(1).max(10).optional(),
+        includeTasks: z.boolean().optional(),
+      })
+      .strict(),
+    minIntervalMs: 5_000,
+    async execute(input) {
+      const { limit = 3, includeTasks = false } = input;
+
+      const assignments = await callGetAPI<Assignment[]>({
+        url: "/v1/assignments",
+        revalidate: false,
+        timeout: DEFAULT_TIMEOUT_MS,
+      });
+
+      const now = Date.now();
+
+      const results = assignments.slice(0, limit).map((assignment) => {
+        const expirationDate = new Date(assignment.expiration);
+        const expiresInSeconds = Math.max(
+          0,
+          Math.floor((expirationDate.getTime() - now) / 1000)
+        );
+
+        return {
+          id: assignment.id,
+          title: assignment.title,
+          briefing: assignment.briefing,
+          description: assignment.description,
+          progress: assignment.progress,
+          reward: assignment.reward,
+          rewards: assignment.rewards,
+          expiration: assignment.expiration,
+          expiresInSeconds,
+          tasks: includeTasks ? assignment.tasks : undefined,
+        };
+      });
+
+      return createSuccessResult("urn:helldivers:mcp:getMajorOrders", {
+        generatedAt: new Date(now).toISOString(),
+        results,
+      });
+    },
+  },
+  getActiveCampaigns: {
+    description: "Provides an overview of active planetary campaigns, optionally filtered by faction.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        faction: {
+          type: "string",
+          description: "Filter campaigns by current planet owner (e.g., Humans, Terminids).",
+        },
+        limit: {
+          type: "integer",
+          minimum: 1,
+          maximum: 50,
+          description: "Maximum number of campaigns to return (defaults to 10).",
+        },
+        includeStatistics: {
+          type: "boolean",
+          description: "Include mission statistics for each campaign (defaults to false).",
+        },
+      },
+      additionalProperties: false,
+    },
+    schema: z
+      .object({
+        faction: z.string().optional(),
+        limit: z.number().int().min(1).max(50).optional(),
+        includeStatistics: z.boolean().optional(),
+      })
+      .strict(),
+    minIntervalMs: 5_000,
+    async execute(input) {
+      const { faction, limit = 10, includeStatistics = false } = input;
+
+      const campaigns = await callGetAPI<Campaign[]>({
+        url: "/v1/campaigns",
+        revalidate: false,
+        timeout: DEFAULT_TIMEOUT_MS,
+      });
+
+      const filtered = campaigns
+        .filter((campaign) => {
+          if (!faction) {
+            return true;
+          }
+          const currentOwner = campaign.planet.currentOwner;
+          const initialOwner = campaign.planet.initialOwner;
+          return (
+            currentOwner?.toLowerCase() === faction.toLowerCase() ||
+            initialOwner?.toLowerCase() === faction.toLowerCase()
+          );
+        })
+        .slice(0, limit)
+        .map((campaign) => ({
+          id: campaign.id,
+          planet: {
+            name: campaign.planet.name,
+            sector: campaign.planet.sector,
+            biome: campaign.planet.biome?.name,
+            hazards: campaign.planet.hazards?.map((hazard) => hazard.name) ?? [],
+            currentOwner: campaign.planet.currentOwner,
+            initialOwner: campaign.planet.initialOwner,
+          },
+          health: {
+            current: campaign.planet.health,
+            max: campaign.planet.maxHealth,
+            regenPerSecond: campaign.planet.regenPerSecond,
+          },
+          statistics: includeStatistics ? campaign.planet.statistics : undefined,
+        }));
+
+      return createSuccessResult("urn:helldivers:mcp:getActiveCampaigns", {
+        total: campaigns.length,
+        results: filtered,
+      });
+    },
+  },
+} satisfies Record<string, ToolDefinition<z.ZodTypeAny>>;
+
+const tools: Record<string, ToolDefinition<z.ZodTypeAny>> = toolDefinitions;
+
+const toolList: Tool[] = Object.entries(tools).map(([name, definition]) => ({
+  name,
+  description: definition.description,
+  inputSchema: definition.inputSchema,
+}));
+
+async function main() {
+  const server = new Server(
+    {
+      name: "helldivers-mcp",
+      version: "0.1.0",
+    },
+    {
+      capabilities: {
+        tools: {},
+      },
+    }
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, () => ({
+    tools: toolList,
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest) => {
+    const { name, arguments: args } = request.params;
+    const definition = tools[name];
+
+    if (!definition) {
+      return createErrorResult(`Unknown tool: ${name}`);
+    }
+
+    const minIntervalMs = definition.minIntervalMs ?? DEFAULT_RATE_LIMIT_MS;
+
+    try {
+      assertRateLimit(name, minIntervalMs);
+    } catch (error) {
+      if (error instanceof Error) {
+        return createErrorResult(error.message);
+      }
+      return createErrorResult("Rate limit exceeded");
+    }
+
+    let parsedInput: unknown;
+    try {
+      parsedInput = definition.schema.parse(args ?? {});
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return createErrorResult("Invalid arguments", error.issues);
+      }
+      return createErrorResult("Failed to parse tool arguments");
+    }
+
+    try {
+      rateLimiter.set(name, Date.now());
+      return await definition.execute(parsedInput);
+    } catch (error) {
+      if (error instanceof Error) {
+        return createErrorResult(error.message);
+      }
+      return createErrorResult("Unexpected error invoking tool");
+    }
+  });
+
+  const transport = new StdioServerTransport();
+
+  server.oninitialized = () => {
+    console.log("[helldivers-mcp] Client connected to MCP server.");
+  };
+
+  await server.connect(transport);
+
+  console.log("[helldivers-mcp] Server ready and listening on stdio.");
+}
+
+main().catch((error) => {
+  console.error("[helldivers-mcp] Failed to start server", error);
+  process.exit(1);
+});

--- a/connectors/helldivers-mcp/src/types/next.d.ts
+++ b/connectors/helldivers-mcp/src/types/next.d.ts
@@ -1,0 +1,7 @@
+declare global {
+  interface RequestInit {
+    next?: Record<string, unknown>;
+  }
+}
+
+export {};

--- a/connectors/helldivers-mcp/tsconfig.json
+++ b/connectors/helldivers-mcp/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "dist",
+    "noEmit": false,
+    "allowJs": false,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@modelcontextprotocol/sdk/*": [
+        "../../node_modules/.pnpm/@modelcontextprotocol+sdk@0.6.1/node_modules/@modelcontextprotocol/sdk/dist/*"
+      ],
+      "@/*": ["../../*"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "connectors:dev": "pnpm --filter helldivers-mcp run dev",
+    "connectors:build": "pnpm --filter helldivers-mcp run build",
+    "connectors:start": "pnpm --filter helldivers-mcp run build && pnpm --filter helldivers-mcp run start"
   },
   "dependencies": {
     "@giscus/react": "^3.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,19 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
 
+  connectors/helldivers-mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^0.6.0
+        version: 0.6.1
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      tsx:
+        specifier: ^4.19.2
+        version: 4.20.5
+
 packages:
 
   '@alloc/quick-lru@5.2.0':
@@ -121,6 +134,162 @@ packages:
 
   '@emnapi/wasi-threads@1.0.4':
     resolution: {integrity: sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==}
+
+  '@esbuild/aix-ppc64@0.25.9':
+    resolution: {integrity: sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.9':
+    resolution: {integrity: sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.9':
+    resolution: {integrity: sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.9':
+    resolution: {integrity: sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.9':
+    resolution: {integrity: sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.9':
+    resolution: {integrity: sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.9':
+    resolution: {integrity: sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.9':
+    resolution: {integrity: sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.9':
+    resolution: {integrity: sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.9':
+    resolution: {integrity: sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.9':
+    resolution: {integrity: sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.9':
+    resolution: {integrity: sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.9':
+    resolution: {integrity: sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.9':
+    resolution: {integrity: sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.9':
+    resolution: {integrity: sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.9':
+    resolution: {integrity: sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.9':
+    resolution: {integrity: sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.9':
+    resolution: {integrity: sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.9':
+    resolution: {integrity: sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.9':
+    resolution: {integrity: sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.9':
+    resolution: {integrity: sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.9':
+    resolution: {integrity: sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.9':
+    resolution: {integrity: sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.9':
+    resolution: {integrity: sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.9':
+    resolution: {integrity: sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.9':
+    resolution: {integrity: sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.7.0':
     resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
@@ -350,6 +519,9 @@ packages:
 
   '@lit/reactive-element@2.1.1':
     resolution: {integrity: sha512-N+dm5PAYdQ8e6UlywyyrgI2t++wFGXfHx+dSJ1oBrg6FAxUj40jId++EaRm80MKX5JnlH1sBsyZ5h0bcZKemCg==}
+
+  '@modelcontextprotocol/sdk@0.6.1':
+    resolution: {integrity: sha512-OkVXMix3EIbB5Z6yife2XTrSlOnVvCLR1Kg91I4pYFEsV9RbnoyQVScXCuVhGaZHOnTZgso8lMQN1Po2TadGKQ==}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -1549,6 +1721,10 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -1607,6 +1783,10 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1659,6 +1839,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
 
   detect-libc@2.0.4:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
@@ -1716,6 +1900,11 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.25.9:
+    resolution: {integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -1892,6 +2081,11 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
@@ -1981,6 +2175,14 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  http-errors@2.0.0:
+    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.7.0:
+    resolution: {integrity: sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==}
+    engines: {node: '>=0.10.0'}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1996,6 +2198,9 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -2519,6 +2724,10 @@ packages:
       '@types/react-dom':
         optional: true
 
+  raw-body@3.0.1:
+    resolution: {integrity: sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==}
+    engines: {node: '>= 0.10'}
+
   react-dom@19.1.0:
     resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
     peerDependencies:
@@ -2615,6 +2824,9 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
 
@@ -2638,6 +2850,9 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sharp@0.34.3:
     resolution: {integrity: sha512-eX2IQ6nFohW4DbvHIOLRB3MHFpYqaqvXd3Tp5e/T/dSH83fxaNJQRvDMhASmkNTsNTVF2/OOopzRCt7xokgPfg==}
@@ -2676,6 +2891,10 @@ packages:
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
+  statuses@2.0.1:
+    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -2763,6 +2982,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
     engines: {node: '>=18.12'}
@@ -2774,6 +2997,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.20.5:
+    resolution: {integrity: sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   tw-animate-css@1.3.6:
     resolution: {integrity: sha512-9dy0R9UsYEGmgf26L8UcHiLmSFTHa9+D7+dAt/G/sF5dCnPePZbfgDYinc7/UzAM7g/baVrmS6m9yEpU46d+LA==}
@@ -2809,6 +3037,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -2896,6 +3128,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
@@ -2919,6 +3154,84 @@ snapshots:
   '@emnapi/wasi-threads@1.0.4':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.25.9':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/android-arm@0.25.9':
+    optional: true
+
+  '@esbuild/android-x64@0.25.9':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.9':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.9':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.9':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.9':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.9':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.9':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.9':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.9':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.9':
     optional: true
 
   '@eslint-community/eslint-utils@4.7.0(eslint@9.32.0(jiti@2.5.1))':
@@ -3114,6 +3427,12 @@ snapshots:
   '@lit/reactive-element@2.1.1':
     dependencies:
       '@lit-labs/ssr-dom-shim': 1.4.0
+
+  '@modelcontextprotocol/sdk@0.6.1':
+    dependencies:
+      content-type: 1.0.5
+      raw-body: 3.0.1
+      zod: 3.25.76
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -4313,6 +4632,8 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  bytes@3.1.2: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -4375,6 +4696,8 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  content-type@1.0.5: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -4426,6 +4749,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  depd@2.0.0: {}
 
   detect-libc@2.0.4: {}
 
@@ -4550,6 +4875,35 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  esbuild@0.25.9:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.9
+      '@esbuild/android-arm': 0.25.9
+      '@esbuild/android-arm64': 0.25.9
+      '@esbuild/android-x64': 0.25.9
+      '@esbuild/darwin-arm64': 0.25.9
+      '@esbuild/darwin-x64': 0.25.9
+      '@esbuild/freebsd-arm64': 0.25.9
+      '@esbuild/freebsd-x64': 0.25.9
+      '@esbuild/linux-arm': 0.25.9
+      '@esbuild/linux-arm64': 0.25.9
+      '@esbuild/linux-ia32': 0.25.9
+      '@esbuild/linux-loong64': 0.25.9
+      '@esbuild/linux-mips64el': 0.25.9
+      '@esbuild/linux-ppc64': 0.25.9
+      '@esbuild/linux-riscv64': 0.25.9
+      '@esbuild/linux-s390x': 0.25.9
+      '@esbuild/linux-x64': 0.25.9
+      '@esbuild/netbsd-arm64': 0.25.9
+      '@esbuild/netbsd-x64': 0.25.9
+      '@esbuild/openbsd-arm64': 0.25.9
+      '@esbuild/openbsd-x64': 0.25.9
+      '@esbuild/openharmony-arm64': 0.25.9
+      '@esbuild/sunos-x64': 0.25.9
+      '@esbuild/win32-arm64': 0.25.9
+      '@esbuild/win32-ia32': 0.25.9
+      '@esbuild/win32-x64': 0.25.9
 
   escalade@3.2.0: {}
 
@@ -4806,6 +5160,9 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  fsevents@2.3.3:
+    optional: true
+
   function-bind@1.1.2: {}
 
   function.prototype.name@1.1.8:
@@ -4898,6 +5255,18 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  http-errors@2.0.0:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      toidentifier: 1.0.1
+
+  iconv-lite@0.7.0:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -4908,6 +5277,8 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  inherits@2.0.4: {}
 
   internal-slot@1.1.0:
     dependencies:
@@ -5408,6 +5779,13 @@ snapshots:
       '@types/react': 19.1.8
       '@types/react-dom': 19.1.6(@types/react@19.1.8)
 
+  raw-body@3.0.1:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.7.0
+      unpipe: 1.0.0
+
   react-dom@19.1.0(react@19.1.0):
     dependencies:
       react: 19.1.0
@@ -5514,6 +5892,8 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  safer-buffer@2.1.2: {}
+
   scheduler@0.26.0: {}
 
   semver@6.3.1: {}
@@ -5541,6 +5921,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
+
+  setprototypeof@1.2.0: {}
 
   sharp@0.34.3:
     dependencies:
@@ -5614,6 +5996,8 @@ snapshots:
   source-map-js@1.2.1: {}
 
   stable-hash@0.0.5: {}
+
+  statuses@2.0.1: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -5719,6 +6103,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   ts-api-utils@2.1.0(typescript@5.8.3):
     dependencies:
       typescript: 5.8.3
@@ -5731,6 +6117,13 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsx@4.20.5:
+    dependencies:
+      esbuild: 0.25.9
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tw-animate-css@1.3.6: {}
 
@@ -5781,6 +6174,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@6.21.0: {}
+
+  unpipe@1.0.0: {}
 
   unrs-resolver@1.11.1:
     dependencies:
@@ -5908,3 +6303,5 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  zod@3.25.76: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - .
+  - connectors/*
 onlyBuiltDependencies:
   - '@tailwindcss/oxide'
   - '@vercel/speed-insights'


### PR DESCRIPTION
## Summary
- tighten the Helldivers MCP server by typing API helpers, enforcing strict JSON schemas, and only recording rate limits after successful validation
- reuse generic callGetAPI responses and expose structured helper types for dispatches, assignments, and campaigns
- document a step-by-step Spanish guide in the README for installing and connecting the MCP server via ChatGPT

## Testing
- pnpm run connectors:build
- pnpm run connectors:start

------
https://chatgpt.com/codex/tasks/task_e_68ca3905b794832db4e26082aa18ace0